### PR TITLE
Enable ruff numpy-style docstring checks

### DIFF
--- a/pwr2/__init__.py
+++ b/pwr2/__init__.py
@@ -1,4 +1,4 @@
-"""Performing power calculations for one and two-way ANOVA models"""
+"""Performing power calculations for one and two-way ANOVA models."""
 
 __version__ = "1.0.0"
 

--- a/pwr2/pwr.py
+++ b/pwr2/pwr.py
@@ -1,3 +1,5 @@
+"""Power and sample size calculations for one- and two-way ANOVA models."""
+
 from math import pow, sqrt
 
 from scipy.stats import f as f_dist

--- a/pwr2/utils.py
+++ b/pwr2/utils.py
@@ -1,3 +1,5 @@
+"""Helper utilities for ANOVA power and sample size calculations."""
+
 from math import pow, sqrt
 
 from scipy.stats import f as f_dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ select = [
     "C4",     # flake8-comprehensions
     "SIM",    # flake8-simplify
     "TCH",    # flake8-type-checking
+    "D",      # pydocstyle
     "RUF",    # Ruff-specific rules
 ]
 ignore = [
@@ -132,3 +133,6 @@ line-ending = "auto"
 
 [tool.ruff.lint.isort]
 known-first-party = ["pwr2"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"


### PR DESCRIPTION
## Summary
- Add the pydocstyle (`D`) rule set to ruff with `convention = "numpy"` so docstrings are linted against the numpy style.
- Fix the resulting violations in the `pwr2` package:
  - `pwr2/__init__.py` — added trailing period (`D400`)
  - `pwr2/pwr.py` — added module docstring (`D100`)
  - `pwr2/utils.py` — added module docstring (`D100`)

Tests are already exempt via the existing `per-file-ignores` for `"D"` on `tests/*`.

## Test plan
- `ruff check pwr2` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)