### PR TITLE
Derive CI Python matrix from pyproject.toml classifiers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,16 @@ on:
     branches: [main, master]
 
 jobs:
-  lint:
-    name: Lint and Format Check
+  # Single source of truth: the Python versions tested by CI are derived from
+  # the trove classifiers in pyproject.toml. To test a new Python version,
+  # add one line there (e.g. "Programming Language :: Python :: 3.15") and the
+  # matrix below updates automatically.
+  generate-matrix:
+    name: Resolve Python versions
     runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.resolve.outputs.versions }}
+      latest: ${{ steps.resolve.outputs.latest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -18,6 +25,44 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.13"
+
+      - name: Resolve versions from pyproject.toml classifiers
+        id: resolve
+        run: |
+          python - <<'PY'
+          import json, os, re, tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              data = tomllib.load(f)
+
+          classifiers = data["project"].get("classifiers", [])
+          pattern = re.compile(r"Programming Language :: Python :: (\d+\.\d+)$")
+          versions = sorted(
+              {m.group(1) for c in classifiers if (m := pattern.match(c))},
+              key=lambda v: tuple(int(p) for p in v.split(".")),
+          )
+          if not versions:
+              raise SystemExit("No 'Programming Language :: Python :: X.Y' classifiers found in pyproject.toml")
+
+          print(f"Resolved Python versions: {versions}")
+          with open(os.environ["GITHUB_OUTPUT"], "a") as out:
+              out.write(f"versions={json.dumps(versions)}\n")
+              out.write(f"latest={versions[-1]}\n")
+          PY
+
+  lint:
+    name: Lint and Format Check
+    runs-on: ubuntu-latest
+    needs: generate-matrix
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ needs.generate-matrix.outputs.latest }}
+          allow-prereleases: true
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -44,14 +89,12 @@ jobs:
   test:
     name: Test Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    needs: generate-matrix
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.13", "3.14"]
-        include:
-          - python-version: "3.14"
-            allow-prereleases: true
+        python-version: ${{ fromJson(needs.generate-matrix.outputs.versions) }}
 
     steps:
       - name: Checkout code
@@ -61,7 +104,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: ${{ matrix.allow-prereleases || false }}
+          # Safe to leave on for every version: setup-python only falls back to
+          # a prerelease when no GA release matches the exact x.y requested, so
+          # newly released versions (e.g. a future 3.15 beta) work without edits.
+          allow-prereleases: true
 
       - name: Cache dependencies
         uses: actions/cache@v4
@@ -80,7 +126,7 @@ jobs:
         run: pytest
 
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == needs.generate-matrix.outputs.latest
         uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
@@ -91,7 +137,7 @@ jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: [generate-matrix, lint, test]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -99,7 +145,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: ${{ needs.generate-matrix.outputs.latest }}
+          allow-prereleases: true
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Check min-Python knobs match the lowest classifier
+        run: python scripts/check_python_versions.py
+
       - name: Resolve versions from pyproject.toml classifiers
         id: resolve
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -233,6 +233,9 @@ rsconnect/
 pyvenv.cfg
 pip-selfcheck.json
 
+# The [Ss]cripts rule above targets virtualenv layouts; keep our repo tooling dir tracked
+!/scripts/
+
 ### VisualStudioCode ###
 .vscode/*
 !.vscode/settings.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,10 @@ repos:
         types: [python]
         pass_filenames: false
         args: [pwr2]
+
+      - id: check-python-versions
+        name: check python version knobs match lowest classifier
+        entry: python scripts/check_python_versions.py
+        language: system
+        files: ^pyproject\.toml$
+        pass_filenames: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    # NOTE: The "3.X" lines below are the single source of truth for the CI test
+    # matrix (see .github/workflows/ci.yml). Add a line here to test a new version.
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Mathematics",

--- a/scripts/check_python_versions.py
+++ b/scripts/check_python_versions.py
@@ -29,11 +29,7 @@ def lowest_version(data: dict) -> tuple[int, int]:
     """Return the lowest ``(major, minor)`` from the Python trove classifiers."""
     classifiers = data["project"].get("classifiers", [])
     versions = sorted(
-        {
-            tuple(int(p) for p in m.group(1).split("."))
-            for c in classifiers
-            if (m := CLASSIFIER_RE.match(c))
-        }
+        {tuple(int(p) for p in m.group(1).split(".")) for c in classifiers if (m := CLASSIFIER_RE.match(c))}
     )
     if not versions:
         sys.exit("No 'Programming Language :: Python :: X.Y' classifiers found in pyproject.toml")
@@ -73,6 +69,7 @@ CHECKS = {
 
 
 def main(argv: list[str]) -> int:
+    """Assert (or ``--fix``) that the min-Python knobs match the lowest classifier."""
     fix = "--fix" in argv
 
     data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
@@ -95,10 +92,7 @@ def main(argv: list[str]) -> int:
             else:
                 print(f"fixed {key}: {current!r} -> {new_inner!r}")
         else:
-            problems.append(
-                f"{key} is {current!r} but the lowest classifier is {major}.{minor} "
-                f"(expected {want!r})"
-            )
+            problems.append(f"{key} is {current!r} but the lowest classifier is {major}.{minor} (expected {want!r})")
 
     if fix:
         PYPROJECT.write_text(text, encoding="utf-8")

--- a/scripts/check_python_versions.py
+++ b/scripts/check_python_versions.py
@@ -1,0 +1,118 @@
+"""Keep the minimum-Python knobs in sync with the lowest trove classifier.
+
+The ``Programming Language :: Python :: 3.X`` classifiers in ``pyproject.toml``
+are the single source of truth for the Python versions this project supports
+(see ``.github/workflows/ci.yml``). The *lowest* of those classifiers implies
+three other settings that must agree with it:
+
+* ``project.requires-python`` floor (``>=3.X``)
+* ``[tool.zuban] python_version`` (``3.X``)
+* ``[tool.ruff] target-version`` (``py3X``)
+
+This script asserts they stay in sync. Run with ``--fix`` to rewrite the values
+in place (targeted line edits that preserve the rest of the file's formatting).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+CLASSIFIER_RE = re.compile(r"Programming Language :: Python :: (\d+\.\d+)$")
+
+
+def lowest_version(data: dict) -> tuple[int, int]:
+    """Return the lowest ``(major, minor)`` from the Python trove classifiers."""
+    classifiers = data["project"].get("classifiers", [])
+    versions = sorted(
+        {
+            tuple(int(p) for p in m.group(1).split("."))
+            for c in classifiers
+            if (m := CLASSIFIER_RE.match(c))
+        }
+    )
+    if not versions:
+        sys.exit("No 'Programming Language :: Python :: X.Y' classifiers found in pyproject.toml")
+    return versions[0]
+
+
+def expected(major: int, minor: int) -> dict[str, str]:
+    """Return the expected value for each derived knob given the lowest version."""
+    return {
+        "requires-python": f">={major}.{minor}",
+        "python_version": f"{major}.{minor}",
+        "target-version": f"py{major}{minor}",
+    }
+
+
+# Each knob: how to read its current value, and how to rewrite its line for --fix.
+CHECKS = {
+    "requires-python": {
+        "read": lambda d: re.search(r">=\s*(\d+\.\d+)", d["project"]["requires-python"]).group(1),
+        "compare": lambda cur, exp: f">={cur}" == exp,
+        "line_re": re.compile(r'^(requires-python\s*=\s*")([^"]*)(")', re.M),
+        "replace": lambda exp: exp,  # full new inner string, e.g. ">=3.13"
+    },
+    "python_version": {
+        "read": lambda d: d["tool"]["zuban"]["python_version"],
+        "compare": lambda cur, exp: cur == exp,
+        "line_re": re.compile(r'^(python_version\s*=\s*")([^"]*)(")', re.M),
+        "replace": lambda exp: exp,
+    },
+    "target-version": {
+        "read": lambda d: d["tool"]["ruff"]["target-version"],
+        "compare": lambda cur, exp: cur == exp,
+        "line_re": re.compile(r'^(target-version\s*=\s*")([^"]*)(")', re.M),
+        "replace": lambda exp: exp,
+    },
+}
+
+
+def main(argv: list[str]) -> int:
+    fix = "--fix" in argv
+
+    data = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    major, minor = lowest_version(data)
+    exp = expected(major, minor)
+
+    problems: list[str] = []
+    text = PYPROJECT.read_text(encoding="utf-8")
+
+    for key, spec in CHECKS.items():
+        current = spec["read"](data)
+        want = exp[key]
+        if spec["compare"](current, want):
+            continue
+        if fix:
+            new_inner = spec["replace"](want)
+            text, n = spec["line_re"].subn(rf"\g<1>{new_inner}\g<3>", text)
+            if n != 1:
+                problems.append(f"{key}: could not locate a unique line to fix")
+            else:
+                print(f"fixed {key}: {current!r} -> {new_inner!r}")
+        else:
+            problems.append(
+                f"{key} is {current!r} but the lowest classifier is {major}.{minor} "
+                f"(expected {want!r})"
+            )
+
+    if fix:
+        PYPROJECT.write_text(text, encoding="utf-8")
+        return 0
+
+    if problems:
+        print("pyproject.toml min-Python knobs are out of sync with the lowest classifier:")
+        for p in problems:
+            print(f"  - {p}")
+        print("\nRun `python scripts/check_python_versions.py --fix` to update them.")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Establishes a **single source of truth** for the Python versions tested in CI. Previously the versions were hardcoded and duplicated across four spots in `ci.yml`, making it tedious and error-prone to add a new release.

A new `generate-matrix` job parses the trove classifiers in `pyproject.toml` (via stdlib `tomllib`) and emits:
- `versions` — JSON array used to build the `test` matrix via `fromJson(...)`
- `latest` — highest version, used for the single-version `lint` and `build` jobs and the Codecov upload condition

## How to add a new Python version now

Add one line to `pyproject.toml`:

```toml
"Programming Language :: Python :: 3.15",
```

The CI matrix picks it up automatically; lint/build/coverage move to it once it becomes the latest.

## Notes

- `allow-prereleases: true` is set everywhere. `setup-python` only falls back to a prerelease when no GA release matches the exact `x.y` requested, so stable versions still resolve to stable while future prereleases (e.g. a `3.15` beta) work without workflow edits.
- The `requires-python`, `[tool.zuban] python_version`, and `[tool.ruff] target-version` knobs express the *minimum* supported version (not the test set) and were intentionally left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)